### PR TITLE
chore: release v0.1.0

### DIFF
--- a/easycar/CHANGELOG.md
+++ b/easycar/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/kamack38/easycar/releases/tag/easycar-v0.1.0) - 2025-06-29
+
+### Added
+
+- 🎸 Make the exam date more readable
+- 🎸 Use feature flags instead of multiple binaries
+- Add OSK mappings and fix null errors:
+- 🎸 Move to the new shuttle platfrom
+
+### Fixed
+
+- 🐛 Apply clippy fixes
+- 🐛 Remove an unnecessary dependency
+- 🐛 Increase delay to prevent timeout
+- 🐛 Don't use the work stealing scheduler
+
+### Other
+
+- 🎡 Fix release
+- 🎡 Fix CI
+- 🤖 Add descriptions for crates
+- 🤖 Improve logging
+- 🤖 Make teloxide use rustls
+- 🤖 Add more logging
+- 🤖 Update dependencies
+- *(deps)* bump tokio from 1.43.0 to 1.43.1
+- 🤖 Apply clippy fixes and update dependencies
+- 🤖 Update dependencies

--- a/info-car-api/CHANGELOG.md
+++ b/info-car-api/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/kamack38/easycar/releases/tag/info-car-api-v0.1.0) - 2025-06-29
+
+### Added
+
+- Add OSK mappings and fix null errors:
+- 🎸 Move to the new shuttle platfrom
+
+### Fixed
+
+- 🐛 Apply clippy fixes
+
+### Other
+
+- 🎡 Fix release
+- 🎡 Fix CI
+- 🤖 Add descriptions for crates
+- 🤖 Remove dependency on native-tls completly
+- 🤖 Apply clippy fixes and update dependencies
+- *(deps)* bump openssl from 0.10.68 to 0.10.71 in /info-car-api
+- 🤖 Update dependencies


### PR DESCRIPTION



## 🤖 New release

* `info-car-api`: 0.1.0
* `easycar`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `info-car-api`

<blockquote>

## [0.1.0](https://github.com/kamack38/easycar/releases/tag/info-car-api-v0.1.0) - 2025-06-29

### Added

- Add OSK mappings and fix null errors:
- 🎸 Move to the new shuttle platfrom

### Fixed

- 🐛 Apply clippy fixes

### Other

- 🎡 Fix release
- 🎡 Fix CI
- 🤖 Add descriptions for crates
- 🤖 Remove dependency on native-tls completly
- 🤖 Apply clippy fixes and update dependencies
- *(deps)* bump openssl from 0.10.68 to 0.10.71 in /info-car-api
- 🤖 Update dependencies
</blockquote>

## `easycar`

<blockquote>

## [0.1.0](https://github.com/kamack38/easycar/releases/tag/easycar-v0.1.0) - 2025-06-29

### Added

- 🎸 Make the exam date more readable
- 🎸 Use feature flags instead of multiple binaries
- Add OSK mappings and fix null errors:
- 🎸 Move to the new shuttle platfrom

### Fixed

- 🐛 Apply clippy fixes
- 🐛 Remove an unnecessary dependency
- 🐛 Increase delay to prevent timeout
- 🐛 Don't use the work stealing scheduler

### Other

- 🎡 Fix release
- 🎡 Fix CI
- 🤖 Add descriptions for crates
- 🤖 Improve logging
- 🤖 Make teloxide use rustls
- 🤖 Add more logging
- 🤖 Update dependencies
- *(deps)* bump tokio from 1.43.0 to 1.43.1
- 🤖 Apply clippy fixes and update dependencies
- 🤖 Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).