### PR TITLE
fix 🐛:  Override existing env when loading secrets from file

### DIFF
--- a/easycar/src/main.rs
+++ b/easycar/src/main.rs
@@ -7,7 +7,7 @@ use info_car_api::types::ProfileIdType;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
-    dotenvy::from_filename("Secrets.toml")?;
+    dotenvy::from_filename_override("Secrets.toml")?;
 
     // Get UserData
     let username = dotenvy::var("USERNAME")?;


### PR DESCRIPTION
[fixed this issue](https://github.com/kamack38/easycar/issues/12)

Changed from ```from_filename``` to ```from_filename_override```, so ENVY don't even try to get the **USERNAME** variable from system env variables.




> [from_filename](https://docs.rs/dotenvy/latest/dotenvy/fn.from_filename.html)
>     Loads environment variables from the specified file.
> [from_filename_iter](https://docs.rs/dotenvy/latest/dotenvy/fn.from_filename_iter.html)
>     Returns an iterator over environment variables from the specified file.
> [from_filename_override](https://docs.rs/dotenvy/latest/dotenvy/fn.from_filename_override.html)
>     Loads environment variables from the specified file, overriding existing environment variables.

source: https://docs.rs/dotenvy/latest/dotenvy/#functions